### PR TITLE
Don't support change of height

### DIFF
--- a/docs/pages/api-docs/masonry-item.json
+++ b/docs/pages/api-docs/masonry-item.json
@@ -4,7 +4,7 @@
     "classes": { "type": { "name": "object" } },
     "columnSpan": { "type": { "name": "number" }, "default": "1" },
     "component": { "type": { "name": "elementType" } },
-    "height": { "type": { "name": "number" } },
+    "defaultHeight": { "type": { "name": "number" } },
     "sx": { "type": { "name": "object" } }
   },
   "name": "MasonryItem",

--- a/docs/translations/api-docs/masonry-item/masonry-item.json
+++ b/docs/translations/api-docs/masonry-item/masonry-item.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "columnSpan": "The number of columns taken up by the component",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
-    "height": "The height of the component in px. This is provided for server-side rendering.",
+    "defaultHeight": "The initial height of the component in px. This is provided for server-side rendering.",
     "sx": "Allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } }

--- a/packages/material-ui-lab/src/MasonryItem/MasonryItem.d.ts
+++ b/packages/material-ui-lab/src/MasonryItem/MasonryItem.d.ts
@@ -14,9 +14,9 @@ export interface MasonryItemTypeMap<P = {}, D extends React.ElementType = 'div'>
      */
     classes?: Partial<MasonryItemClasses>;
     /**
-     * The height of the component in px. This is provided for server-side rendering.
+     * The initial height of the component in px. This is provided for server-side rendering.
      */
-    height?: number;
+    defaultHeight?: number;
     /**
      * The number of columns taken up by the component
      * @default 1

--- a/packages/material-ui-lab/src/MasonryItem/MasonryItem.test.js
+++ b/packages/material-ui-lab/src/MasonryItem/MasonryItem.test.js
@@ -110,7 +110,7 @@ describe('<MasonryItem />', () => {
 
     it('should compute grid-row-end based on given height', () => {
       const { getByTestId } = render(
-        <MasonryItem height={150} data-testid="test-root">
+        <MasonryItem defaultHeight={150} data-testid="test-root">
           {children}
         </MasonryItem>,
       );


### PR DESCRIPTION
Moved from https://github.com/mui-org/material-ui/pull/27439#discussion_r684940510

First I just wanted to move the derived state to render time when I realized that this is just controlled vs uncontrolled components. Mixing these concepts in a single component makes it harder to reason about than necessary. 

It seems like we can just use the `default*` pattern instead until we understand why a MasonryItem needs to have a controlled height while responding to resizes. It's not obvious which value should win. 

If people do want to change the initial height due to a different item (e.g. image) being displayed then they can use `key` to get the previous behavior. This also seems more intuitive assuming you do understand the `key` prop in React.