### PR TITLE
Maybe fix

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -184,6 +184,9 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     const handleResize = () => {
+      if (!masonryRef.current.firstChild) {
+        return;
+      }
       const parentWidth = masonryRef.current.clientWidth;
       const childWidth = masonryRef.current.firstChild.clientWidth;
       const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -184,7 +184,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   React.useEffect(() => {
     const handleResize = () => {
-      if (!masonryRef.current.firstChild) {
+      if (!masonryRef.current || !masonryRef.current.firstChild) {
         return;
       }
       const parentWidth = masonryRef.current.clientWidth;

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -186,7 +186,6 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
     typeof ResizeObserver === 'undefined'
       ? undefined
       : new ResizeObserver((elements) => {
-          console.log(elements);
           const masonry = elements[0];
           const masonryFirstChild = elements[1];
           if (!masonryFirstChild) {

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -182,84 +182,98 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  React.useEffect(() => {
-    const handleResize = () => {
-      if (!masonryRef.current || !masonryRef.current.firstChild) {
-        return;
-      }
-      const parentWidth = masonryRef.current.clientWidth;
-      const childWidth = masonryRef.current.firstChild.clientWidth;
-      const firstChildComputedStyle = window.getComputedStyle(masonryRef.current.firstChild);
-      const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
-      const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
-
-      if (parentWidth === 0 || childWidth === 0) {
-        return;
-      }
-
-      const currentNumberOfColumns = Math.round(
-        parentWidth / (childWidth + firstChildMarginLeft + firstChildMarginRight),
-      );
-
-      const columnHeights = new Array(currentNumberOfColumns).fill(0);
-      let skip = false;
-      masonryRef.current.childNodes.forEach((child) => {
-        if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
-          return;
-        }
-        const childComputedStyle = window.getComputedStyle(child);
-        const childMarginTop = parseToNumber(childComputedStyle.marginTop);
-        const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
-        // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
-        const childHeight = parseToNumber(childComputedStyle.height)
-          ? Math.ceil(parseToNumber(childComputedStyle.height)) + childMarginTop + childMarginBottom
-          : 0;
-        if (childHeight === 0) {
-          skip = true;
-          return;
-        }
-        // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
-        for (let i = 0; i < child.childNodes.length; i += 1) {
-          const nestedChild = child.childNodes[i];
-          if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
-            skip = true;
-            break;
+  const observer = React.useRef(
+    typeof ResizeObserver === 'undefined'
+      ? undefined
+      : new ResizeObserver((elements) => {
+          console.log(elements);
+          const masonry = elements[0];
+          const masonryFirstChild = elements[1];
+          if (!masonryFirstChild) {
+            return;
           }
-        }
-        if (!skip) {
-          // find the current shortest column (where the current item will be placed)
-          const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
-          columnHeights[currentMinColumnIndex] += childHeight;
-          const order = currentMinColumnIndex + 1;
-          child.style.order = order;
-        }
-      });
-      if (!skip) {
-        setMaxColumnHeight(Math.max(...columnHeights));
-        const numOfLineBreaks = currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0;
-        setNumberOfLineBreaks(numOfLineBreaks);
-      }
-    };
+          const parentWidth = masonry.target.clientWidth;
+          const childWidth = masonryFirstChild.target.clientWidth;
+          const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild.target);
+          const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
+          const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
 
+          if (parentWidth === 0 || childWidth === 0) {
+            return;
+          }
+
+          const currentNumberOfColumns = Math.round(
+            parentWidth / (childWidth + firstChildMarginLeft + firstChildMarginRight),
+          );
+
+          const columnHeights = new Array(currentNumberOfColumns).fill(0);
+          let skip = false;
+
+          const childNodes = masonry.target.childNodes;
+          childNodes.forEach((child) => {
+            if (
+              child.nodeType !== Node.ELEMENT_NODE ||
+              child.dataset.class === 'line-break' ||
+              skip
+            ) {
+              return;
+            }
+            const childComputedStyle = window.getComputedStyle(child);
+            const childMarginTop = parseToNumber(childComputedStyle.marginTop);
+            const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
+            // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
+            const childHeight = parseToNumber(childComputedStyle.height)
+              ? Math.ceil(parseToNumber(childComputedStyle.height)) +
+                childMarginTop +
+                childMarginBottom
+              : 0;
+            if (childHeight === 0) {
+              skip = true;
+              return;
+            }
+            // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
+            for (let i = 0; i < child.childNodes.length; i += 1) {
+              const nestedChild = child.childNodes[i];
+              if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
+                skip = true;
+                break;
+              }
+            }
+            if (!skip) {
+              // find the current shortest column (where the current item will be placed)
+              const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+              columnHeights[currentMinColumnIndex] += childHeight;
+              const order = currentMinColumnIndex + 1;
+              child.style.order = order;
+            }
+          });
+          if (!skip) {
+            setMaxColumnHeight(Math.max(...columnHeights));
+            const numOfLineBreaks = currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0;
+            setNumberOfLineBreaks(numOfLineBreaks);
+          }
+        }),
+  );
+
+  React.useEffect(() => {
     // IE and old browsers are not supported
     if (typeof ResizeObserver === 'undefined') {
       return undefined;
     }
-    const resizeObserver = new ResizeObserver(handleResize);
 
     const container = masonryRef.current;
     if (container) {
       // only the masonry container and its first child are observed for resizing;
       // this might cause unforeseen problems in some use cases;
-      resizeObserver.observe(container);
+      observer.current.observe(container);
       if (container.firstChild) {
-        resizeObserver.observe(container.firstChild);
+        observer.current.observe(container.firstChild);
       }
     }
     return () => {
-      resizeObserver.disconnect();
+      observer.current.disconnect();
     };
-  }, [columns, spacing, children]);
+  }, [columns, spacing, children, observer.current]);
 
   const handleRef = useForkRef(ref, masonryRef);
   const lineBreakStyle = {

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -52,6 +52,25 @@ describe('<Masonry />', () => {
         width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing)})`,
       });
     });
+
+    it('should throw console error when children are empty', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+        'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+      );
+    });
+
+    it('should not throw type error when children are empty', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      expect(() => render(<Masonry columns={3} spacing={1} />)).toErrorDev(
+        'Warning: Failed prop type: The prop `children` is marked as required in `ForwardRef(Masonry)`, but its value is `undefined`.',
+      );
+      expect(() => render(<Masonry columns={3} spacing={1} />)).not.to.throw(new TypeError());
+    });
   });
 
   describe('style attribute:', () => {

--- a/test/regressions/fixtures/Masonry/EmptyMasonry.js
+++ b/test/regressions/fixtures/Masonry/EmptyMasonry.js
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import Masonry from '@mui/lab/Masonry';
-
-export default function EmptyMasonry() {
-  return <Masonry columns={3} spacing={1} />;
-}

--- a/test/regressions/fixtures/Masonry/EmptyMasonry.js
+++ b/test/regressions/fixtures/Masonry/EmptyMasonry.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Masonry from '@mui/lab/Masonry';
+
+export default function EmptyMasonry() {
+  return <Masonry columns={3} spacing={1} />;
+}


### PR DESCRIPTION
I could find two problems.

- I think that we need only one ResizeObserver instance, we can store it in ref. (I am not sure if this change is required) I would maybe revert it, so that we can isolate the problem better
- In the `handleResize` we should depend on the elements args, not the ref we have in the component. elements[0].target would give you the masonry ref

I haven't tested this very much, but it solved the issue as far as I could see.
